### PR TITLE
Crop for selection tool

### DIFF
--- a/sources/datasingleton.cpp
+++ b/sources/datasingleton.cpp
@@ -82,6 +82,7 @@ void DataSingleton::readSetting()
     mEditShortcuts.insert("Copy", settings.value("/Shortcuts/Edit/Copy", QKeySequence(QKeySequence::Copy)).value<QKeySequence>());
     mEditShortcuts.insert("Paste", settings.value("/Shortcuts/Edit/Paste", QKeySequence(QKeySequence::Paste)).value<QKeySequence>());
     mEditShortcuts.insert("Cut", settings.value("/Shortcuts/Edit/Cut", QKeySequence(QKeySequence::Cut)).value<QKeySequence>());
+    mEditShortcuts.insert("Crop", settings.value("/Shortcuts/Edit/Crop", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_X)).value<QKeySequence>());
 
     //read shortcuts for instruments menu
     mInstrumentsShortcuts.insert("Cursor", settings.value("/Shortcuts/Instruments/Cursor", "Ctrl+1").value<QKeySequence>());

--- a/sources/imagearea.cpp
+++ b/sources/imagearea.cpp
@@ -380,6 +380,11 @@ void ImageArea::cutImage()
     instrument->cutImage(*this);
 }
 
+void ImageArea::cropImage()
+{
+    SelectionInstrument *instrument = static_cast <SelectionInstrument*> (mInstrumentsHandlers.at(CURSOR));
+    instrument->cropImage(*this);
+}
 void ImageArea::mousePressEvent(QMouseEvent *event)
 {
     if(event->button() == Qt::LeftButton &&

--- a/sources/imagearea.h
+++ b/sources/imagearea.h
@@ -157,6 +157,7 @@ public:
      *
      */
     void cutImage();
+    void cropImage();
     /**
      * @brief Save all image changes to image copy.
      *

--- a/sources/instruments/selectioninstrument.cpp
+++ b/sources/instruments/selectioninstrument.cpp
@@ -91,6 +91,17 @@ void SelectionInstrument::cutImage(ImageArea &imageArea)
     }
 }
 
+void SelectionInstrument::cropImage(ImageArea &imageArea)
+{
+    QImage cropArea = imageArea.getImage()->copy(mTopLeftPoint.x(), mTopLeftPoint.y(), mWidth, mHeight);
+    makeUndoCommand(imageArea);
+    imageArea.setImage(cropArea);
+    imageArea.update();
+    mIsSelectionExists = false;
+    imageArea.restoreCursor();
+    emit sendEnableCopyCutActions(false);
+}
+
 void SelectionInstrument::pasteImage(ImageArea &imageArea)
 {
     QClipboard *globalClipboard = QApplication::clipboard();

--- a/sources/instruments/selectioninstrument.h
+++ b/sources/instruments/selectioninstrument.h
@@ -69,6 +69,7 @@ public:
      * @param imageArea ImageArea for applying changes.
      */
     void cutImage(ImageArea &imageArea);
+    void cropImage(ImageArea &imageArea);
 
 private:
     void startAdjusting(ImageArea &imageArea);

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -238,6 +238,14 @@ void MainWindow::initializeMainMenu()
     connect(mCutAction, &QAction::triggered, this, &MainWindow::cutAct);
     editMenu->addAction(mCutAction);
 
+    mCropAction = new QAction(tr("Crop S&election"));
+    mCropAction->setIcon(QIcon::fromTheme("transform-crop"));
+    mCropAction->setIconVisibleInMenu(true);
+    mCropAction->setEnabled(false);
+    connect(mCropAction, &QAction::triggered, this, &MainWindow::cropAct);
+    editMenu->addAction(mCropAction);
+
+
     editMenu->addSeparator();
 
     QAction *settingsAction = new QAction(tr("&Settings"), this);
@@ -613,6 +621,12 @@ void MainWindow::cutAct()
         imageArea->cutImage();
 }
 
+void MainWindow::cropAct()
+{
+    if (ImageArea *imageArea = getCurrentImageArea())
+        imageArea->cropImage();
+}
+
 void MainWindow::updateShortcuts()
 {
     mNewAction->setShortcut(DataSingleton::Instance()->getFileShortcutByKey("New"));
@@ -628,6 +642,7 @@ void MainWindow::updateShortcuts()
     mCopyAction->setShortcut(DataSingleton::Instance()->getEditShortcutByKey("Copy"));
     mPasteAction->setShortcut(DataSingleton::Instance()->getEditShortcutByKey("Paste"));
     mCutAction->setShortcut(DataSingleton::Instance()->getEditShortcutByKey("Cut"));
+    mCropAction->setShortcut(DataSingleton::Instance()->getEditShortcutByKey("Crop"));
 
     mInstrumentsActMap[CURSOR]->setShortcut(DataSingleton::Instance()->getInstrumentShortcutByKey("Cursor"));
     mInstrumentsActMap[ERASER]->setShortcut(DataSingleton::Instance()->getInstrumentShortcutByKey("Lastic"));
@@ -870,6 +885,7 @@ void MainWindow::enableCopyCutActions(bool enable)
 {
     mCopyAction->setEnabled(enable);
     mCutAction->setEnabled(enable);
+    mCropAction->setEnabled(enable);
 }
 
 void MainWindow::clearImageSelection()

--- a/sources/mainwindow.h
+++ b/sources/mainwindow.h
@@ -106,7 +106,7 @@ private:
     QMap<InstrumentsEnum, QAction*> mInstrumentsActMap;
     QMap<EffectsEnum, QAction*> mEffectsActMap;
     QAction *mSaveAction, *mSaveAsAction, *mCloseAction, *mPrintAction,
-            *mUndoAction, *mRedoAction, *mCopyAction, *mCutAction,
+            *mUndoAction, *mRedoAction, *mCopyAction, *mCutAction, *mCropAction,
             *mNewAction, *mOpenAction, *mExitAction, *mPasteAction, *mZoomInAction, *mZoomOutAction;
     QMenu *mInstrumentsMenu, *mEffectsMenu, *mToolsMenu;
     QUndoGroup *mUndoStackGroup;
@@ -128,6 +128,7 @@ private slots:
     void copyAct();
     void pasteAct();
     void cutAct();
+    void cropAct();
     void settingsAct();
     void effectsAct();
     void resizeImageAct();


### PR DESCRIPTION
1. Select an area of the image with the Selection tool.
2. Press CTRL + SHIFT + X or choose Crop Selection from the Edit menu.
source: https://github.com/ognjen-petrovic/EasyPaint/commit/d1f818520f73b0060748e07f98bdef0fd9e4a133